### PR TITLE
🧑‍💻 Fix: 아이디 중복 시 Label 표시 및 text field 흔들림 효과 적용

### DIFF
--- a/KickScooter/Presentation/Scene/Shared/View/InvalidLabel.swift
+++ b/KickScooter/Presentation/Scene/Shared/View/InvalidLabel.swift
@@ -3,6 +3,7 @@ import UIKit
 final class InvalidLabel: UILabel {
     var emptyText: String?
     var invalidText: String?
+    var duplicatedIDText: String?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -28,6 +29,11 @@ final class InvalidLabel: UILabel {
 
     func showInvalidMessage() {
         text = invalidText
+        isHidden = false
+    }
+
+    func showduplicatedIDMessage() {
+        text = duplicatedIDText
         isHidden = false
     }
 }

--- a/KickScooter/Presentation/Scene/SignUp/ViewController/SignUpViewController.swift
+++ b/KickScooter/Presentation/Scene/SignUp/ViewController/SignUpViewController.swift
@@ -103,6 +103,7 @@ final class SignUpViewController: UIViewController {
 
         invalidIDLabel.emptyText = "아이디를 입력해주세요."
         invalidIDLabel.invalidText = "아이디는 영문과 숫자만 사용할 수 있습니다."
+        invalidIDLabel.duplicatedIDText = "이미 사용중인 아이디입니다."
 
         invalidPasswordLabel.emptyText = "비밀번호를 입력해주세요."
         invalidPasswordLabel.invalidText = "비밀번호는 최소 8자 이상이어야 합니다."
@@ -160,15 +161,22 @@ final class SignUpViewController: UIViewController {
 
             let isValidated = self.validateTextFields()
 
+            if !isValidated { return }
+
             guard let id = self.idTextField.text else { return }
             let isAvialable = self.signUpViewModel.verifyIDAvailability(id)
 
-            if isValidated, isAvialable {
+            if isAvialable {
                 guard let user = self.user() else { return }
 
                 self.signUpViewModel.signUp(user: user)
 
                 self.delegate?.pop()
+            } else {
+                invalidIDLabel.showduplicatedIDMessage()
+                
+                _ = idTextField.becomeFirstResponder()
+                idTextField.shake()
             }
         }
     }


### PR DESCRIPTION
## 🔗 관련 작업  
- #31 

## ✨ 변경 사항  
- 아이디 중복 시 Label 표시 및 TextField 흔들림 효과 적용

## 🔍 변경 이유  
- UX

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 확인했나요?  
- [ ] 관련된 테스트를 추가하거나 수정했나요?  
- [ ] 문서를 업데이트했나요? (필요한 경우)  
- [ ] PR 제목이 적절한가요?  
- [ ] 커밋 메시지가 명확한가요?  
- [ ] 불필요한 파일이나 변경 사항이 포함되지 않았나요?  
- [ ] 코드 스타일 및 포맷팅을 맞췄나요?  
- [ ] 기존 기능을 깨뜨리지 않았나요?  
- [ ] 리뷰어가 이해하기 쉽게 설명이 충분한가요?  

## 📸 변경 사항 (스크린샷 또는 동영상)  
https://github.com/user-attachments/assets/b2af628f-de61-4a6f-97b5-67b18ffc271a