### PR TITLE
🧑‍💻 Fix: 마이페이지 - Your Ride, Past Rides 데이터 바인딩

### DIFF
--- a/KickScooter/Data/Mapper/UserResponseMapper.swift
+++ b/KickScooter/Data/Mapper/UserResponseMapper.swift
@@ -15,12 +15,22 @@ struct UserResponseMapper {
     }
 
     func map(from response: UserResponse) -> User {
-        User(
+        guard let reservations = response.reservations else {
+            return User(
+                id: response.id,
+                password: response.password,
+                name: response.name,
+                email: response.email,
+                reservations: []
+            )
+        }
+
+        return User(
             id: response.id,
             password: response.password,
             name: response.name,
             email: response.email,
-            reservations: response.reservations.map { reservationMapper.map(from: $0) }
+            reservations: reservations.map { reservationMapper.map(from: $0) }
         )
     }
 

--- a/KickScooter/Data/Model/UserResponse.swift
+++ b/KickScooter/Data/Model/UserResponse.swift
@@ -3,5 +3,5 @@ struct UserResponse {
     let email: String
     let id: String
     let password: String
-    let reservations: [ReservationResponse]
+    let reservations: [ReservationResponse]?
 }

--- a/KickScooter/Presentation/Mapper/ReservationUIMapper.swift
+++ b/KickScooter/Presentation/Mapper/ReservationUIMapper.swift
@@ -6,7 +6,7 @@ struct ReservationUIMapper {
     func map(reservations: [Reservation]) -> [ReservationUI] {
         reservations.map {
             let reservation = ReservationUI(
-                date: "\($0.date)",
+                date: $0.date,
                 status: $0.status,
                 startLon: $0.startLon,
                 startLat: $0.startLat,

--- a/KickScooter/Presentation/Model/ReservationUI.swift
+++ b/KickScooter/Presentation/Model/ReservationUI.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct ReservationUI: Hashable {
-    let date: String
+    let date: Date
     let status: Bool
     let startLon: Double
     let startLat: Double

--- a/KickScooter/Presentation/Model/UserProfileUI.swift
+++ b/KickScooter/Presentation/Model/UserProfileUI.swift
@@ -2,5 +2,6 @@ struct UserProfileUI: Hashable, NameableUI, EmailableUI, IdableUI {
     let name: String
     let email: String
     let id: String
-    let reservations: [ReservationUI]
+//    let reservations: [ReservationUI]
+    var reservations: [ReservationUI]
 }

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/Enum/MyPageItem.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/Enum/MyPageItem.swift
@@ -1,6 +1,6 @@
 enum MyPageItem: Hashable {
     case userProfile(UserProfileUI)
-    case yourRide
-    case pastRides(PastRidesMock)
+    case yourRide(ReservationUI)
+    case pastRides(ReservationUI)
     case signOutButton
 }

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
@@ -9,8 +9,6 @@ final class MyPageViewController: UIViewController {
 
     weak var delegate: MyPageViewControllerDelegate?
 
-    let pastRidesMock: [PastRidesMock] = PastRidesMock.pastRidesMock
-
     init(myPageViewModel: MyPageViewModel) {
         self.myPageViewModel = myPageViewModel
         super.init(nibName: nil, bundle: nil)

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/MyPageViewController.swift
@@ -23,9 +23,10 @@ final class MyPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureCompositionalLayout()
+        myPageViewModel.action?(.fetchUserProfile)
         configureUI()
         configureAutoLayout()
+        configureCompositionalLayout()
     }
 
     private func fetchProfileUser() -> UserProfileUI {
@@ -43,7 +44,7 @@ final class MyPageViewController: UIViewController {
 
     private func configureAutoLayout() {
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(40)
             $0.directionalHorizontalEdges.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview()
         }

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/PastRidesMock.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/PastRidesMock.swift
@@ -1,61 +1,124 @@
 import Foundation
 
-struct PastRidesMock: Hashable {
-    let id: UUID = .init()
-    let date: String
-    let totalTime: String
-    let start: String
-    let end: String
-    let scooterImg: String
-    let scooterModel: String
-    let priceValue: String
-}
-
-extension PastRidesMock {
-    static let pastRidesMock: [PastRidesMock] = [
-        PastRidesMock(
-            date: "2025년 3월 22일 (월)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123",
-            end: "서울시 강남구 역삼대로 4",
-            scooterImg: "KickScooter1",
-            scooterModel: "가성비 킥보드",
-            priceValue: "15,000원"
-        ),
-        PastRidesMock(
-            date: "2025년 3월 10일 (수)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123", end: "서울시 강남구 역삼대로 4", scooterImg: "KickScooter3", scooterModel: "가성비 킥보드", priceValue: "25,000원"
-        ),
-        PastRidesMock(
-            date: "2025년 3월 8일 (일)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123", end: "서울시 강남구 역삼대로 4", scooterImg: "KickScooter2", scooterModel: "가성비 킥보드", priceValue: "15,000원"
-        ),
-        PastRidesMock(
-            date: "2025년 1월 2일 (월)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123", end: "서울시 강남구 역삼대로 4", scooterImg: "KickScooter1", scooterModel: "가성비 킥보드", priceValue: "15,000원"
-        ),
-        PastRidesMock(
-            date: "2025년 3월 22일 (월)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123", end: "서울시 강남구 역삼대로 4", scooterImg: "KickScooter1", scooterModel: "가성비 킥보드", priceValue: "15,000원"
-        ),
-        PastRidesMock(
-            date: "2025년 3월 10일 (수)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123", end: "서울시 강남구 역삼대로 4", scooterImg: "KickScooter3", scooterModel: "비싼 킥보드", priceValue: "15,000원"
-        ),
-        PastRidesMock(
-            date: "2025년 3월 8일 (일)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123", end: "서울시 강남구 역삼대로 4", scooterImg: "KickScooter2", scooterModel: "비싼 킥보드", priceValue: "15,000원"
-        ),
-        PastRidesMock(
-            date: "2025년 1월 2일 (월)",
-            totalTime: "1시간 5분 3초",
-            start: "서울시 강남구 역삼대로 123", end: "서울시 강남구 역삼대로 4", scooterImg: "KickScooter1", scooterModel: "가성비 킥보드", priceValue: "15,000원"
-        ),
-    ]
-}
+let mockReservationsUI: [ReservationUI] = [
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 22).date!,
+        status: false,
+        startLon: 127.0351, startLat: 37.5010,
+        endLon: 127.0287, endLat: 37.4994,
+        startAddress: "서울시 강남구 역삼대로 123",
+        endAddress: "서울시 강남구 역삼대로 4",
+        totalTime: "1시간 5분 3초",
+        totalPrice: "15,000원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "50", type: 1,
+            lon: 127.0351, lat: 37.5010,
+            isAvailable: false
+        )
+    ),
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 23).date!,
+        status: false,
+        startLon: 126.9780, startLat: 37.5665,
+        endLon: 126.9900, endLat: 37.5700,
+        startAddress: "서울시 중구 세종대로 1",
+        endAddress: "서울시 종로구 종로 100",
+        totalTime: "45분 12초",
+        totalPrice: "9,000원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "100", type: 0,
+            lon: 126.9780, lat: 37.5665,
+            isAvailable: false
+        )
+    ),
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 24).date!,
+        status: false,
+        startLon: 127.0600, startLat: 37.5100,
+        endLon: 127.0650, endLat: 37.5150,
+        startAddress: "서울시 송파구 올림픽로 300",
+        endAddress: "서울시 송파구 백제고분로 45",
+        totalTime: "30분 8초",
+        totalPrice: "7,000원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "50", type: 2,
+            lon: 127.0600, lat: 37.5100,
+            isAvailable: false
+        )
+    ),
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 25).date!,
+        status: false,
+        startLon: 126.9950, startLat: 37.5700,
+        endLon: 127.0000, endLat: 37.5730,
+        startAddress: "서울시 종로구 종로1길 10",
+        endAddress: "서울시 종로구 율곡로 50",
+        totalTime: "20분 15초",
+        totalPrice: "5,000원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "25", type: 1,
+            lon: 126.9950, lat: 37.5700,
+            isAvailable: false
+        )
+    ),
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 26).date!,
+        status: false,
+        startLon: 127.0300, startLat: 37.5200,
+        endLon: 127.0350, endLat: 37.5250,
+        startAddress: "서울시 강남구 도산대로 45",
+        endAddress: "서울시 강남구 학동로 12",
+        totalTime: "1시간 2분 48초",
+        totalPrice: "13,500원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "25", type: 0,
+            lon: 127.0300, lat: 37.5200,
+            isAvailable: false
+        )
+    ),
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 29).date!,
+        status: true,
+        startLon: 127.0100, startLat: 37.5650,
+        endLon: 127.0150, endLat: 37.5700,
+        startAddress: "서울시 중구 충무로 1",
+        endAddress: "서울시 중구 필동로 3길",
+        totalTime: "29분 59초",
+        totalPrice: "6,800원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "50", type: 0,
+            lon: 127.0100, lat: 37.5650,
+            isAvailable: false
+        )
+    ),
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 27).date!,
+        status: false,
+        startLon: 127.0450, startLat: 37.5080,
+        endLon: 127.0500, endLat: 37.5120,
+        startAddress: "서울시 서초구 반포대로 87",
+        endAddress: "서울시 서초구 서초대로 200",
+        totalTime: "38분 10초",
+        totalPrice: "8,500원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "50", type: 1,
+            lon: 127.0450, lat: 37.5080,
+            isAvailable: false
+        )
+    ),
+    ReservationUI(
+        date: DateComponents(calendar: .current, year: 2025, month: 3, day: 28).date!,
+        status: false,
+        startLon: 127.0230, startLat: 37.5500,
+        endLon: 127.0300, endLat: 37.5520,
+        startAddress: "서울시 성동구 왕십리로 222",
+        endAddress: "서울시 성동구 행당로 100",
+        totalTime: "52분 33초",
+        totalPrice: "11,000원",
+        kickScooter: KickScooterUI(
+            id: UUID(), battery: "100", type: 2,
+            lon: 127.0230, lat: 37.5500,
+            isAvailable: false
+        )
+    ),
+]

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/MyPageCollectionView.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/MyPageCollectionView.swift
@@ -63,7 +63,8 @@ extension MyPageCollectionView {
     private func layout() -> UICollectionViewCompositionalLayout {
         UICollectionViewCompositionalLayout { sectionIndex, _ in
             // sectionIndex : 현재 섹션의 번호
-            // _ (= environment : 화면 사이즈,  traits 등 정보 포함
+            // _ (= environment) : 화면 사이즈,  traits 등 정보 포함
+
             let section = MyPageSection.allCases[sectionIndex]
 
             // 1. 공통 Item, Group 정의

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/PastRidesCell.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/PastRidesCell.swift
@@ -38,7 +38,7 @@ final class PastRidesCell: UICollectionViewCell {
     private func configureUI() {
         backgroundColor = .triOSTertiaryBackground
 
-        dateLabel.font = .boldSystemFont(ofSize: 16)
+        dateLabel.font = .jalnan(ofSize: 16)
         dateLabel.textColor = .triOSText
 
         totalTimeLabel.text = "총 시간"
@@ -137,6 +137,10 @@ final class PastRidesCell: UICollectionViewCell {
         startValue.text = reservation.startAddress
         endValue.text = reservation.endAddress
         priceValue.text = reservation.totalPrice
+
+        if let image = KickScooterType(rawValue: reservation.kickScooter.type)?.image {
+            scooterImageView.image = UIImage(named: image)
+        }
     }
 
     private func configureAutoLayout() {

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/PastRidesCell.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/PastRidesCell.swift
@@ -132,17 +132,11 @@ final class PastRidesCell: UICollectionViewCell {
     }
 
     func configureProperty(_ reservation: ReservationUI) {
-        dateLabel.text = reservation.date
-    }
-
-    func configurePropertyMock(_ pastRide: PastRidesMock) {
-        dateLabel.text = pastRide.date
-        totalTimeValue.text = pastRide.totalTime
-        startValue.text = pastRide.start
-        endValue.text = pastRide.end
-        scooterImageView.image = UIImage(named: pastRide.scooterImg)
-        scooterLabel.text = pastRide.scooterModel
-        priceValue.text = pastRide.priceValue
+        dateLabel.text = Formatter.getFormattedDate(from: reservation.date)
+        totalTimeValue.text = reservation.totalTime
+        startValue.text = reservation.startAddress
+        endValue.text = reservation.endAddress
+        priceValue.text = reservation.totalPrice
     }
 
     private func configureAutoLayout() {

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/YourRideCell.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/Subview/YourRideCell.swift
@@ -65,7 +65,6 @@ final class YourRideCell: UICollectionViewCell {
         naviImage.tintColor = .triOSMain
         naviImage.contentMode = .scaleAspectFill
 
-        totalTime.text = "1시간 10분 6초"
         totalTime.font = .jalnan(ofSize: 13)
         totalTime.textColor = .triOSText
 
@@ -77,14 +76,12 @@ final class YourRideCell: UICollectionViewCell {
         batteryIconView.backgroundColor = .triOSHighBatteryBackground
 
         batteryIcon.contentMode = .center
-        batteryIcon.image = UIImage(systemName: "battery.100")
         batteryIcon.tintColor = .triOSHighBattery
 
         batteryLabel.text = "배터리"
         batteryLabel.font = .jalnan(ofSize: 12)
         batteryLabel.textColor = .triOSSecondaryText
 
-        batteryValue.text = "100%"
         batteryValue.font = .jalnan(ofSize: 12)
         batteryValue.textColor = .triOSText
 
@@ -138,7 +135,33 @@ final class YourRideCell: UICollectionViewCell {
     }
 
     func configureProperty(_ reservation: ReservationUI) {
-        totalTime.text = reservation.date
+        totalTime.text = Formatter.getTotalTime(from: reservation.date)
+
+        if let image = KickScooterType(rawValue: reservation.kickScooter.type)?.image {
+            scooterImageView.image = UIImage(named: image)
+        }
+
+        if let battery = Double(reservation.kickScooter.battery),
+           let batteryLevel = BatteryLevel(desc: battery)
+        {
+            switch batteryLevel {
+            case .high:
+                batteryIconView.backgroundColor = .triOSHighBatteryBackground
+                batteryIcon.image = UIImage(systemName: "battery.100")
+                batteryIcon.tintColor = .triOSHighBattery
+                batteryValue.text = "\(Int(battery))%"
+            case .mid:
+                batteryIconView.backgroundColor = .triOSMidBatteryBackground
+                batteryIcon.image = UIImage(systemName: "battery.50")
+                batteryIcon.tintColor = .triOSMidBattery
+                batteryValue.text = "\(Int(battery))%"
+            case .low:
+                batteryIconView.backgroundColor = .triOSLowBatteryBackground
+                batteryIcon.image = UIImage(systemName: "battery.25")
+                batteryIcon.tintColor = .triOSLowBattery
+                batteryValue.text = "\(Int(battery))%"
+            }
+        }
     }
 
     private func configureAutoLayout() {

--- a/KickScooter/Presentation/Scene/MyPage/ViewController/Util/Formatter.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewController/Util/Formatter.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum Formatter {
+    static func getTotalTime(
+        from startTime: Date,
+        _ endTime: Date = Date()
+    ) -> String {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents(
+            [.hour, .minute, .second],
+            from: startTime,
+            to: endTime
+        )
+
+        guard let hour = components.hour,
+              let minute = components.minute,
+              let second = components.second
+        else {
+            return ""
+        }
+
+        return String(format: "%02시간 %02분 %02초", hour, minute, second)
+    }
+
+    static func getFormattedDate(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 M월 d일 (E)"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: date)
+    }
+}

--- a/KickScooter/Presentation/Scene/MyPage/ViewModel/MyPageViewModel.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewModel/MyPageViewModel.swift
@@ -39,7 +39,7 @@ final class MyPageViewModel: MyPageViewModelDelegate {
             guard let self else { return }
             switch action {
             case .fetchUserProfile:
-                let userProfile = self.fetchUserProfile()
+                let userProfile = fetchUserProfile()
                 self.userProfile = userProfile
                 self.onStateChanged?(.userProfile(userProfile))
             }

--- a/KickScooter/Presentation/Scene/MyPage/ViewModel/MyPageViewModel.swift
+++ b/KickScooter/Presentation/Scene/MyPage/ViewModel/MyPageViewModel.swift
@@ -50,7 +50,14 @@ final class MyPageViewModel: MyPageViewModelDelegate {
         let id = fetchUserIDUseCase.execute()
         let user = myPageUseCase.fetchUserProfile(id)
 
-        return mapper.map(user: user)
+        // delete
+        var userui = mapper.map(user: user)
+        for item in mockReservationsUI {
+            userui.reservations.append(item)
+        }
+
+//        return mapper.map(user: user)
+        return userui
     }
 
     func signOut() {


### PR DESCRIPTION
## 🔗 관련 작업  
- #64 

## ✨ 변경 사항  
- Mock 데이터를 실제 데이터 모델로 변경
- 테스트를 위해 Mock 데이터로 UI 에 잘 들어가는지 확인

## 🔍 변경 이유  
-  Mock 데이터를 실제 데이터 모델로 변경
-  테스트를 위해 Mock 데이터로 UI 에 잘 들어가는지 확인

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했나요?  
- [ ] 관련된 테스트를 추가하거나 수정했나요?  
- [ ] 문서를 업데이트했나요? (필요한 경우)  
- [x] PR 제목이 적절한가요?  
- [x] 커밋 메시지가 명확한가요?  
- [x] 불필요한 파일이나 변경 사항이 포함되지 않았나요?  
- [x] 코드 스타일 및 포맷팅을 맞췄나요?  
- [x] 기존 기능을 깨뜨리지 않았나요?  
- [x] 리뷰어가 이해하기 쉽게 설명이 충분한가요?  

## 📸 변경 사항 (스크린샷 또는 동영상)  

### 1. 실제 데이터 모델로 변경 - 예약 없어서 로그아웃만 보임

https://github.com/user-attachments/assets/7a38a1e5-48c7-4b5d-8b43-4784c61679cf

## 🚀 추가 정보  
- compositional layout 특성상 셀순서에 맞게 높이를 계산해서, 
   동영상에서 처럼 현재 예약 / 과거 예약 데이터가 없어서 셀을 안그려줄때는 로그아웃이 저렇게 올라오는게 지금으로는 최선인거가터유...
   예약 기능 완료되면 테스트 해보면 될것같습니다
   찾아보니 layout 틀을 동적으로 변동 못한다고 하네요

- +) 로그아웃 오토레이아웃을 최대한 밑으로 내려도, 유저프로필 다음 셀의 높이에서 가장 밑에 그려서.. 그것도 애매하더라고요
   차라리 가운데가 나은것 같습니다..